### PR TITLE
Improve handling for multiple testsuites

### DIFF
--- a/lua/neotest-bun/util/bun.lua
+++ b/lua/neotest-bun/util/bun.lua
@@ -53,10 +53,10 @@ function bun.xmlToResults(root, xml)
   local parser = xml2lua.parser(handler)
   parser:parse(xml)
 
-  local testsuites = bun.ensureIsSequence(handler.root.testsuites)
+  local testsuites = bun.ensureIsSequence(handler.root.testsuites.testsuite)
 
   for _, testsuite in ipairs(testsuites) do
-    local testcases = bun.ensureIsSequence(testsuite.testsuite.testcase)
+    local testcases = bun.ensureIsSequence(testsuite.testcase)
     for _, testcase in ipairs(testcases) do
       local attrs = testcase._attr
       local status

--- a/lua/neotest-bun/util/bun.lua
+++ b/lua/neotest-bun/util/bun.lua
@@ -54,7 +54,6 @@ function bun.xmlToResults(root, xml)
   parser:parse(xml)
 
   local testsuites = bun.ensureIsSequence(handler.root.testsuites.testsuite)
-
   for _, testsuite in ipairs(testsuites) do
     local testcases = bun.ensureIsSequence(testsuite.testcase)
     for _, testcase in ipairs(testcases) do

--- a/tests/fixtures/junit/two-testsuites.xml
+++ b/tests/fixtures/junit/two-testsuites.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="bun test" tests="4" assertions="4" failures="0" skipped="0" time="1.40058">
+  <testsuite name="test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx" tests="2" assertions="2" failures="0" skipped="0" time="0.027" hostname="Justins-MacBook-Pro.local">
+    <testcase name="renders attributes from the ModelDetail" classname="DetailsDrawer" time="0.0247" file="test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx" assertions="11" />
+    <testcase name="renders attributes from a minimally filled ModelDetail" classname="DetailsDrawer" time="0.003427" file="test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx" assertions="2" />
+  </testsuite>
+  <testsuite name="test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx" tests="2" assertions="12" failures="0" skipped="0" time="0.005" hostname="Justins-MacBook-Pro.local">
+    <testcase name="renders attributes from the Subscription" classname="SubscriptionDrawer" time="0.003906" file="test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx" assertions="11" />
+    <testcase name="renders attributes from a Legacy System Subscription" classname="SubscriptionDrawer" time="0.002907" file="test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx" assertions="1" />
+  </testsuite>
+</testsuites>

--- a/tests/util/test_bun.lua
+++ b/tests/util/test_bun.lua
@@ -106,6 +106,29 @@ T["bun.xmlToResults()"]["considers a test to pass if it's not skipped or failed"
   MiniTest.expect.equality(expected, results)
 end
 
+T["bun.xmlToResults()"]["handles output with two testsuites"] = function()
+  local xml = Helpers.readFixtureFile("junit/two-testsuites.xml")
+  local root = "/root/path"
+
+  local results = bun.xmlToResults(root, xml)
+
+  local expected = {
+    ["/root/path/test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx::DetailsDrawer::renders attributes from a minimally filled ModelDetail"] = {
+      status = "passed"
+    },
+    ["/root/path/test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx::DetailsDrawer::renders attributes from the ModelDetail"] = {
+      status = "passed"
+    },
+    ["/root/path/test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx::SubscriptionDrawer::renders attributes from a Legacy System Subscription"] = {
+      status = "passed"
+    },
+    ["/root/path/test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx::SubscriptionDrawer::renders attributes from the Subscription"] = {
+      status = "passed"
+    }
+  }
+  MiniTest.expect.equality(expected, results)
+end
+
 -- T["setup()"]["overrides default values"] = function()
 --   child.lua([[require('neotest-bun').setup({
 --         -- write all the options with a value different than the default ones

--- a/tests/util/test_bun.lua
+++ b/tests/util/test_bun.lua
@@ -113,18 +113,18 @@ T["bun.xmlToResults()"]["handles output with two testsuites"] = function()
   local results = bun.xmlToResults(root, xml)
 
   local expected = {
-    ["/root/path/test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx::DetailsDrawer::renders attributes from a minimally filled ModelDetail"] = {
-      status = "passed"
+    [root .."/test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx::DetailsDrawer::renders attributes from a minimally filled ModelDetail"] = {
+      status = "passed",
     },
-    ["/root/path/test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx::DetailsDrawer::renders attributes from the ModelDetail"] = {
-      status = "passed"
+    [root .."/test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx::DetailsDrawer::renders attributes from the ModelDetail"] = {
+      status = "passed",
     },
-    ["/root/path/test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx::SubscriptionDrawer::renders attributes from a Legacy System Subscription"] = {
-      status = "passed"
+    [root .."/test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx::SubscriptionDrawer::renders attributes from a Legacy System Subscription"] = {
+      status = "passed",
     },
-    ["/root/path/test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx::SubscriptionDrawer::renders attributes from the Subscription"] = {
-      status = "passed"
-    }
+    [root .."/test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx::SubscriptionDrawer::renders attributes from the Subscription"] = {
+      status = "passed",
+    },
   }
   MiniTest.expect.equality(expected, results)
 end


### PR DESCRIPTION
This happens if you run `bun test` with a directory which contains multiple files. You can do this via neotest's test panel. Basically we just have to account for there being more than one test suite, which changes the structure of the parsed xml table a little bit.
