### PR TITLE
Improve support for nested describe blocks

### DIFF
--- a/tests/fixtures/junit/nested-describe.xml
+++ b/tests/fixtures/junit/nested-describe.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="bun test" tests="7" assertions="11" failures="0" skipped="0" time="0.673653">
+  <testsuite name="test/frontend/components/Layout/AppRoot.test.tsx" tests="7" assertions="11" failures="0" skipped="0" time="0.116" hostname="Justins-MacBook-Pro.local">
+    <testcase name="renders the marketplace navigation for marketplace users" classname="when the component is rendered &amp;gt; AppRoot" time="0.054451" file="test/frontend/components/Layout/AppRoot.test.tsx" assertions="2" />
+    <testcase name="renders the service portal navigation for marketplace  and service portal users" classname="when the component is rendered &amp;gt; AppRoot" time="0.01525" file="test/frontend/components/Layout/AppRoot.test.tsx" assertions="2" />
+  </testsuite>
+</testsuites>

--- a/tests/util/test_bun.lua
+++ b/tests/util/test_bun.lua
@@ -20,6 +20,7 @@ local T = MiniTest.new_set({
 T["bun.fileExists()"] = MiniTest.new_set()
 T["bun.isBunProject()"] = MiniTest.new_set()
 T["bun.ensureIsSequence()"] = MiniTest.new_set()
+T["bun.parseClassname()"] = MiniTest.new_set()
 T["bun.xmlToResults()"] = MiniTest.new_set()
 
 T["bun.fileExists()"]["is true if the file exists"] = function()
@@ -59,6 +60,18 @@ end
 T["bun.ensureIsSequence()"]["if the argument is already a sequence of tables, does nothing"] = function()
   local sequenceOfTables = { { status = "passed" }, { status = "failed" } }
   MiniTest.expect.equality(sequenceOfTables, bun.ensureIsSequence(sequenceOfTables))
+end
+
+T["bun.parseClassname()"]["handles nested describe blocks"] = function()
+  local classname = "when the component is rendered &gt; AppRoot"
+  local actual = bun.parseClassname(classname)
+  MiniTest.expect.equality("AppRoot::when the component is rendered", actual)
+end
+
+T["bun.parseClassname()"]["doesn't modify classnames which aren't nested"] = function()
+  local classname = "AppRoot"
+  local actual = bun.parseClassname(classname)
+  MiniTest.expect.equality("AppRoot", actual)
 end
 
 T["bun.xmlToResults()"]["parses junit with a single failure"] = function()
@@ -113,16 +126,16 @@ T["bun.xmlToResults()"]["handles output with two testsuites"] = function()
   local results = bun.xmlToResults(root, xml)
 
   local expected = {
-    [root .."/test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx::DetailsDrawer::renders attributes from a minimally filled ModelDetail"] = {
+    [root .. "/test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx::DetailsDrawer::renders attributes from a minimally filled ModelDetail"] = {
       status = "passed",
     },
-    [root .."/test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx::DetailsDrawer::renders attributes from the ModelDetail"] = {
+    [root .. "/test/frontend/pages/MarketplaceModels/DetailsDrawer.test.tsx::DetailsDrawer::renders attributes from the ModelDetail"] = {
       status = "passed",
     },
-    [root .."/test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx::SubscriptionDrawer::renders attributes from a Legacy System Subscription"] = {
+    [root .. "/test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx::SubscriptionDrawer::renders attributes from a Legacy System Subscription"] = {
       status = "passed",
     },
-    [root .."/test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx::SubscriptionDrawer::renders attributes from the Subscription"] = {
+    [root .. "/test/frontend/pages/MarketplaceModels/SubscriptionDrawer.test.tsx::SubscriptionDrawer::renders attributes from the Subscription"] = {
       status = "passed",
     },
   }
@@ -136,10 +149,10 @@ T["bun.xmlToResults()"]["handles output with nested describe blocks"] = function
   local results = bun.xmlToResults(root, xml)
 
   local expected = {
-    [root .."/test/frontend/components/Layout/AppRoot.test.tsx::AppRoot::when the component is rendered::renders the marketplace navigation for marketplace users"] = {
+    [root .. "/test/frontend/components/Layout/AppRoot.test.tsx::AppRoot::when the component is rendered::renders the marketplace navigation for marketplace users"] = {
       status = "passed",
     },
-    [root .."test/frontend/components/Layout/AppRoot.test.tsx::AppRoot::when the component is rendered::renders the service portal navigation for marketplace  and service portal users"] = {
+    [root .. "/test/frontend/components/Layout/AppRoot.test.tsx::AppRoot::when the component is rendered::renders the service portal navigation for marketplace  and service portal users"] = {
       status = "passed",
     },
   }

--- a/tests/util/test_bun.lua
+++ b/tests/util/test_bun.lua
@@ -129,6 +129,23 @@ T["bun.xmlToResults()"]["handles output with two testsuites"] = function()
   MiniTest.expect.equality(expected, results)
 end
 
+T["bun.xmlToResults()"]["handles output with nested describe blocks"] = function()
+  local xml = Helpers.readFixtureFile("junit/nested-describe.xml")
+  local root = "/root/path"
+
+  local results = bun.xmlToResults(root, xml)
+
+  local expected = {
+    [root .."/test/frontend/components/Layout/AppRoot.test.tsx::AppRoot::when the component is rendered::renders the marketplace navigation for marketplace users"] = {
+      status = "passed",
+    },
+    [root .."test/frontend/components/Layout/AppRoot.test.tsx::AppRoot::when the component is rendered::renders the service portal navigation for marketplace  and service portal users"] = {
+      status = "passed",
+    },
+  }
+  MiniTest.expect.equality(expected, results)
+end
+
 -- T["setup()"]["overrides default values"] = function()
 --   child.lua([[require('neotest-bun').setup({
 --         -- write all the options with a value different than the default ones


### PR DESCRIPTION
The junit output from these is a little weird, so we have to handle the
`classname` field specially in this case.