### PR TITLE
Remove lazy workaround

### DIFF
--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -36,19 +36,12 @@ require("lazy").setup({
       },
     },
     { "echasnovski/mini.nvim", version = "*" },
-    { dir = ".", build = false },
+    { dir = "." },
   },
   install = { colorscheme = { "habamax" } },
 })
 
--- Only install plugins if this isn't a test child process
-if not vim.env.NVIM then
-  require("lazy").install({ wait = true })
-
-  -- Install xml2lua dependency manually since lazy.nvim's luarocks has issues
-  local lazy_rocks_path = vim.fn.stdpath("data") .. "/lazy-rocks/_"
-  vim.fn.system({"luarocks", "--tree=" .. lazy_rocks_path, "install", "xml2lua"})
-end
+require("lazy").install({ wait = true })
 
 -- Add current directory to 'runtimepath' to be able to use 'lua' files
 vim.cmd([[let &rtp.=','.getcwd()]])


### PR DESCRIPTION
I had added a little hacky fix to get the xml2lua dependency installed locally and on CI. For some reason lazy wasn't installing it on its own. I have since found out that this is because I didn't publish a non-dev version of this package to luarocks, and something about how dependencies are looked up needed that to be the case. Now that there's a package published, xml2lua is installed correctly.