### PR TITLE
remove note about needing lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,5 @@ not sure about other plugin managers.
 require("lazy").setup({ "jutonz/neotest-bun" })
 ```
 
-Because this plugin has some lua dependencies, you'll also need lua 5.1
-installed on your computer. This is easiest to do by adding `lua 5.1` to your
-`.tool-versions` file if you're using asdf or mise.
-
 [lazy.nvim]: https://github.com/folke/lazy.nvim
 


### PR DESCRIPTION
Lazy will use `hererocks` to install lua dependencies if lua isn't present on the machine, so this part of the readme is no longer necessary.