### PR TITLE
Allow passing in additional command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,22 @@ require("neotest").setup({
 ```
 
 [lazy.nvim]: https://github.com/folke/lazy.nvim
+
+## Configuration
+
+You can pass in config options when requiring the adapter.
+
+```lua
+require("neotest-bun")({
+  additional_args = { "--coverage" },
+})
+```
+
+Here are the defaults:
+
+```lua
+{
+  test_command = "bun test",
+  additional_args = {},
+}
+```

--- a/doc/neotest-bun.txt
+++ b/doc/neotest-bun.txt
@@ -26,6 +26,10 @@ Default values:
   NeotestBun.options = {
     -- Prints useful logs about what event are triggered, and reasons actions are executed.
     debug = false,
+    -- Command used to run bun tests.
+    test_command = "bun test",
+    -- Additional command line arguments to pass to the test command.
+    additional_args = {},
   }
 
 <

--- a/lua/neotest-bun/config.lua
+++ b/lua/neotest-bun/config.lua
@@ -10,6 +10,10 @@ local NeotestBun = {}
 NeotestBun.options = {
   -- Prints useful logs about what event are triggered, and reasons actions are executed.
   debug = false,
+  -- Command used to run bun tests.
+  test_command = "bun test",
+  -- Additional command line arguments to pass to the test command.
+  additional_args = {},
 }
 
 ---@private

--- a/lua/neotest-bun/init.lua
+++ b/lua/neotest-bun/init.lua
@@ -173,6 +173,7 @@ function NeotestBun.build_position(file_path, source, captured_nodes)
 end
 
 NeotestBun.build_spec = function(args)
+  local options = require("neotest-bun.config").options
   local results_path = async.fn.tempname() .. ".xml"
   local tree = args.tree
 
@@ -181,12 +182,13 @@ NeotestBun.build_spec = function(args)
   end
 
   local pos = args.tree:data()
-  local binary = "bun test"
+  local binary = options.test_command
   local command = vim.split(binary, "%s+")
   vim.list_extend(command, {
     "--reporter=junit",
     "--reporter-outfile=" .. results_path,
   })
+  vim.list_extend(command, options.additional_args)
 
   local testNamePattern = nil
 
@@ -212,13 +214,6 @@ NeotestBun.build_spec = function(args)
   vim.list_extend(command, {
     vim.fs.normalize(pos.path),
   })
-  --
-  -- command = vim.split("bun test test/frontend/pages/Providers/Index.test.tsx", "%s+")
-  -- vim.list_extend(command, {
-  --   "-t=^ Index renders a list of Providers$",
-  --   "--reporter=junit",
-  --   "--reporter-outfile=" .. results_path,
-  -- })
 
   -- creating empty file for streaming results
   lib.files.write(results_path, "")

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -261,7 +261,9 @@ Helpers.setupNeotest = function(child)
   child.lua([[
     require("neotest").setup({
       adapters = {
-        require("neotest-bun")({ debug = true })
+        require("neotest-bun")({
+          debug = true,
+        })
       },
       icons = {
         child_indent = "│",


### PR DESCRIPTION
This adds a new config option `additional_args` which can be used to add new args to `bun test`